### PR TITLE
Enhancements on LOG-LINE.

### DIFF
--- a/src/elb-log.lisp
+++ b/src/elb-log.lisp
@@ -58,6 +58,9 @@
                 :log-line-request-method
                 :log-line-request-uri
                 :log-line-request-protocol
+                :log-line-user-agent
+                :log-line-ssl-cipher
+                :log-line-ssl-protocol
                 :make-log-line)
   (:export ;; globals
            :*elb-log*
@@ -109,6 +112,9 @@
            :log-line-request-method
            :log-line-request-uri
            :log-line-request-protocol
+           :log-line-user-agent
+           :log-line-ssl-cipher
+           :log-line-ssl-protocol
 
            ;; macros
            :with-elb-log

--- a/src/struct.lisp
+++ b/src/struct.lisp
@@ -161,7 +161,19 @@ BUCKET-NAME should be bucket name of ELB log."
 
  (is (log-line-request-protocol obj)
      "HTTP/1.1"
-     "can set request-protocol."))
+     "can set request-protocol.")
+
+ (is (log-line-user-agent obj)
+     "curl/7.38.0"
+     "can set user-agent.")
+
+ (is (log-line-ssl-cipher obj)
+     "-"
+     "can set ssl-cipher.")
+
+ (is (log-line-ssl-protocol obj)
+     "-"
+     "can set ssl-protocol."))
 @doc
 "Struct of ELB log line."
 (defstruct (log-line (:constructor %make-log-line))
@@ -180,7 +192,10 @@ BUCKET-NAME should be bucket name of ELB log."
   (sent-bytes nil :type (or null integer))
   (request-method nil :type (or null string))
   (request-uri nil :type (or null string))
-  (request-protocol nil :type (or null string)))
+  (request-protocol nil :type (or null string))
+  (user-agent nil :type (or null string))
+  (ssl-cipher nil :type (or null string))
+  (ssl-protocol nil :type (or null string)))
 
 @export
 (defun make-log-line (string)
@@ -188,7 +203,7 @@ BUCKET-NAME should be bucket name of ELB log."
                          (#'parse-integer backend-port)
                          (#'read-from-string request-processing-time backend-processing-time response-processing-time)
                          (#'parse-integer elb-status-code backend-status-code received-bytes sent-bytes)
-                         request-method request-uri request-protocol)
+                         request-method request-uri request-protocol user-agent ssl-cipher ssl-protocol)
       (*log-line-scanner* string)
     (%make-log-line :time time
                     :elb-name elb-name
@@ -205,4 +220,7 @@ BUCKET-NAME should be bucket name of ELB log."
                     :sent-bytes sent-bytes
                     :request-method request-method
                     :request-uri request-uri
-                    :request-protocol request-protocol)))
+                    :request-protocol request-protocol
+                    :user-agent user-agent
+                    :ssl-cipher ssl-cipher
+                    :ssl-protocol ssl-protocol)))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -21,7 +21,7 @@
 (defvar *sample-key* "AWSLogs/123456789012/elasticloadbalancing/us-west-2/2014/02/15/123456789012_elasticloadbalancing_us-west-2_my-loadbalancer_20140215T2340Z_172.160.001.192_20sg8hgm.log")
 
 @export
-(defvar *sample-log* "2014-02-15T23:39:43.945958Z my-loadbalancer 192.168.131.39:2817 10.0.0.1:80 0.000073 0.001048 0.000057 200 200 0 29 \"GET http://www.example.com:80/ HTTP/1.1\"")
+(defvar *sample-log* "2014-02-15T23:39:43.945958Z my-loadbalancer 192.168.131.39:2817 10.0.0.1:80 0.000073 0.001048 0.000057 200 200 0 29 \"GET http://www.example.com:80/ HTTP/1.1\" \"curl/7.38.0\" - -")
 
 @export
 @tests
@@ -37,7 +37,7 @@
 ((is (scan-to-strings *log-line-scanner* *sample-log*)
      *sample-log*
      "can scan the whole line."))
-(defvar *log-line-scanner* (create-scanner #?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) (.+)\:(.+) (.+)\:(.+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?) (.+?)\"$/))
+(defvar *log-line-scanner* (create-scanner #?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) (.+)\:(.+) (.+)\:(.+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?) (.+?)\" \"(.+?)\" (.+?) (.+?)$/))
 
 @export
 @tests

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -37,7 +37,7 @@
 ((is (scan-to-strings *log-line-scanner* *sample-log*)
      *sample-log*
      "can scan the whole line."))
-(defvar *log-line-scanner* (create-scanner #?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) (.+)\:(.+) (.+)\:(.+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?) (.+?)\" \"(.+?)\" (.+?) (.+?)$/))
+(defvar *log-line-scanner* (create-scanner #?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) ([\d.]+)\:(\d+) ([\d.]+)\:(\d+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?) (.+?)\" \"(.+?)\" (.+?) (.+?)$/))
 
 @export
 @tests

--- a/t/struct.lisp
+++ b/t/struct.lisp
@@ -99,6 +99,18 @@
 
     (is (log-line-request-protocol obj)
         "HTTP/1.1"
-        "can set request-protocol.")))
+        "can set request-protocol.")
+
+    (is (log-line-user-agent obj)
+        "curl/7.38.0"
+        "can set user-agent.")
+
+    (is (log-line-ssl-cipher obj)
+        "-"
+        "can set ssl-cipher.")
+
+    (is (log-line-ssl-protocol obj)
+        "-"
+        "can set ssl-protocol.")))
 
 (finalize)


### PR DESCRIPTION
The original regex is so ambiguous that it leads poor performance with
a lot of backtrack.

```
(let ((elb-log::*log-line-scanner* (ppcre:create-scanner
#?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) (.+)\:(.+)
(.+)\:(.+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?)
(.+?)\" \"(.+?)\" (.+?) (.+?)$/)))
           (time (loop repeat 1000 do (elb-log::make-log-line
elb-log::*sample-log*))))
Evaluation took:
  0.379 seconds of real time
  0.379369 seconds of total run time (0.378424 user, 0.000945 system)
  100.00% CPU
  854,614,123 processor cycles
  3,305,072 bytes consed
```

```
(let ((elb-log::*log-line-scanner* (ppcre:create-scanner
#?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) (.+)\:(\d+)
(.+)\:(\d+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?)
(.+?)\" \"(.+?)\" (.+?) (.+?)$/)))
           (time (loop repeat 1000 do (elb-log::make-log-line
elb-log::*sample-log*))))

Evaluation took:
  0.039 seconds of real time
  0.039800 seconds of total run time (0.036091 user, 0.003709 system)
  102.56% CPU
  88,984,264 processor cycles
  3,305,424 bytes consed
```

```
(let ((elb-log::*log-line-scanner* (ppcre:create-scanner
#?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?)
([\d.]+)\:(\d+) ([\d.]+)\:(\d+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?)
(.+?) \"(.+?) (.+?) (.+?)\" \"(.+?)\" (.+?) (.+?)$/)))
           (time (loop repeat 1000 do (elb-log::make-log-line
elb-log::*sample-log*))))

Evaluation took:
  0.030 seconds of real time
  0.030604 seconds of total run time (0.030534 user, 0.000070 system)
  103.33% CPU
  69,016,073 processor cycles
  3,305,232 bytes consed
```
