### PR TITLE
Enhancements on LOG-LINE.

### DIFF
--- a/src/elb-log.lisp
+++ b/src/elb-log.lisp
@@ -285,9 +285,10 @@ DATE should be an instance of loca-time:timestamp."
 @doc
 "Return a list of #S(log-line)."
 (defun log-lines (log-key &key (bucket *log-bucket*))
-  (let ((stream (make-string-input-stream (get-string (bucket-name (car (log-bucket-buckets bucket)))
-                                                      (log-key-key log-key)
-                                                      :credentials (log-bucket-elb-log bucket)))))
-    (loop for line = (read-line stream nil)
-          while line
-          collecting (make-log-line line))))
+  (let ((flexi-streams:*substitution-char* #\-))
+    (let ((stream (make-string-input-stream (get-string (bucket-name (car (log-bucket-buckets bucket)))
+                                                        (log-key-key log-key)
+                                                        :credentials (log-bucket-elb-log bucket)))))
+      (loop for line = (read-line stream nil)
+            while line
+            collecting (make-log-line line)))))

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -24,6 +24,9 @@
 (defvar *sample-log* "2014-02-15T23:39:43.945958Z my-loadbalancer 192.168.131.39:2817 10.0.0.1:80 0.000073 0.001048 0.000057 200 200 0 29 \"GET http://www.example.com:80/ HTTP/1.1\" \"curl/7.38.0\" - -")
 
 @export
+(defvar *sample-log2* "2014-02-15T23:39:43.945958Z my-loadbalancer 192.168.131.39:2817 10.0.0.1:80 0.000073 0.001048 0.000057 200 200 0 29 \"GET http://www.example.com:80/ HTTP/1.1\" \"\" - -")
+
+@export
 @tests
 ((is (scan-to-strings *key-scanner* *sample-key*)
      *sample-key*
@@ -37,7 +40,7 @@
 ((is (scan-to-strings *log-line-scanner* *sample-log*)
      *sample-log*
      "can scan the whole line."))
-(defvar *log-line-scanner* (create-scanner #?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) ([\d.]+)\:(\d+) ([\d.]+)\:(\d+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?) (.+?)\" \"(.+?)\" (.+?) (.+?)$/))
+(defvar *log-line-scanner* (create-scanner #?/^(\d{4}-\d{2}-\d{2}T\d{2}\:\d{2}\:\d{2}\.\d{6}Z) (.+?) ([\d.]+)\:(\d+) ([\d.]+)\:(\d+) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) (.+?) \"(.+?) (.+?) (.+?)\" \"(.*)\" (.+?) (.+?)$/))
 
 @export
 @tests

--- a/src/util.lisp
+++ b/src/util.lisp
@@ -33,7 +33,7 @@
      "can scan the whole key."))
 (defvar *key-scanner* (create-scanner #?/^AWSLogs\/([0-9]{12})\/elasticloadbalancing\/(.+?)\/([0-9]{4}\/[0-9]{2}\/[0-9]{2})\/[0-9]{12}_elasticloadbalancing_.+?_([^_]+)_([0-9]{8}T[0-9]{4}Z)_(.+?)_(.+).log/))
 
-(defvar *timestamp-scanner* (create-scanner #?/^([1-9][0-9]{3})(0[1-9]|11|12)(0[1-9]|[1-3][0-9])T([0-2][0-9])([0-5][0-9])Z$/))
+(defvar *timestamp-scanner* (create-scanner #?/^([1-9][0-9]{3})(0[1-9]|10|11|12)(0[1-9]|[1-3][0-9])T([0-2][0-9])([0-5][0-9])Z$/))
 
 @export
 @tests

--- a/t/util.lisp
+++ b/t/util.lisp
@@ -34,6 +34,10 @@
   (is (parse-timestamp "20140215T2339Z")
       (encode-timestamp 0 0 39 23 15 02 2014 :timezone +utc-zone+)
       "can parse YYYYMMDDTHHmmZ."
+      :test #'timestamp=)
+  (is (parse-timestamp "20141015T2339Z")
+      (encode-timestamp 0 0 39 23 15 10 2014 :timezone +utc-zone+)
+      "can parse YYYYMMDDTHHmmZ in October."
       :test #'timestamp=))
 
 (subtest "format-date"

--- a/t/util.lisp
+++ b/t/util.lisp
@@ -18,7 +18,11 @@
 (subtest "*log-line-scanner*"
   (is (scan-to-strings *log-line-scanner* *sample-log*)
       *sample-log*
-      "can scan the whole line."))
+      "can scan the whole line.")
+
+  (is (scan-to-strings *log-line-scanner* *sample-log2*)
+      *sample-log2*
+      "can scan the whole line with empty user-agent."))
 
 (subtest "parse-date"
   (is (parse-date "2014/12/31")


### PR DESCRIPTION
Includes two commits on log-line.

One is about empty user agents, my fault on the former pull request.

The other is in case that log lines in ELB log happen to have invalid bytes for UTF-8, causing FLEXI-STREAMS:EXTERNAL-FORMAT-ENCODING-ERROR. This time I choose #\\- because it is one of unreserved characters for URI, though you may want to use another character or even another way to solve this.
